### PR TITLE
include man page in default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DINSTALLINCLUDE=$(DESTDIR)$(INSTALLINCLUDE)
 VERSION=$(shell sh version.sh)
 PACKAGE=fex-$(VERSION)
 
-all: fex
+all: fex fex.1
 
 test:
 	cd t; sh test.sh


### PR DESCRIPTION
The workflow of 'make && make install' is pretty common but doesn't work
with the existing Makefile because the 'install' target tries to install a
man page that isn't built by default.
