### PR TITLE
Fix buffer over-read on field extraction

### DIFF
--- a/fex.c
+++ b/fex.c
@@ -152,6 +152,11 @@ void process_line(char *buf, int len, int argc, char **argv) {
 }
 
 char *extract(char *format, char *buf) {
+  if (format[0] == '\0') {
+    fprintf(stderr, "Empty format string...\n");
+    exit(1);
+  }
+
   char *sep = NULL;
 
   char *buffer = strdup(buf);


### PR DESCRIPTION
fex would read past argv if given an empty argument. This usually
manifests as printing environment variables or the next argument
(including parsing that argument by skipping the initial \0). This just
adds a check to the extract function to do roughly the same thing as
other argument errors: print a polite message and exit.