### PR TITLE
Fix "make install" error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: fex
 test:
 	cd t; sh test.sh
 
-install: fex
+install: fex fex.1
 	install -d $(DINSTALLBIN)
 	install -m 755 fex $(DINSTALLBIN)/
 	install -d $(DINSTALLMAN)


### PR DESCRIPTION
- 'make install' after downloading (or 'make clean') no longer fails with "install: cannot stat 'fex.1': No such file or directory"